### PR TITLE
line that was breaking turbolinking when founding package.json in the same file

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,6 @@ process.on('exit', cleanup)
 function checkdir () {
   fs.stat(path.join(dirname, PKG), (err) => {
     console.log('TURBOLINK'.underline.bold)
-    if (!err) { dirname = path.dirname(dirname) }
     if (settings) {
       console.log('from .turbolink settings file'.green)
       if (settings.repos) {


### PR DESCRIPTION
I made a bootstrap repository for kickstart vigour projects in here: https://github.com/vigour-io/www. 

But in case of using turbolink locally, I need to have a `package.json` file in root repository to install turbolink. 

But when it saw that file in `www` dir, this line which I removed was breaking process and did some weird actions :))

I did not see any use case of this one, and offering remove it.
